### PR TITLE
Update to willdurand/geocoder version 3.2

### DIFF
--- a/02-features/traits/Geocodable.php
+++ b/02-features/traits/Geocodable.php
@@ -9,7 +9,7 @@ trait Geocodable {
     /** @var \Geocoder\Result\Geocoded */
     protected $geocoderResult;
 
-    public function setGeocoder(\Geocoder\GeocoderInterface $geocoder)
+    public function setGeocoder(\Geocoder\Geocoder $geocoder)
     {
         $this->geocoder = $geocoder;
     }
@@ -25,7 +25,7 @@ trait Geocodable {
             $this->geocodeAddress();
         }
 
-        return $this->geocoderResult->getLatitude();
+        return $this->geocoderResult->first()->getLatitude();
     }
 
     public function getLongitude()
@@ -34,7 +34,7 @@ trait Geocodable {
             $this->geocodeAddress();
         }
 
-        return $this->geocoderResult->getLongitude();
+        return $this->geocoderResult->first()->getLongitude();
     }
 
     protected function geocodeAddress()

--- a/02-features/traits/composer.json
+++ b/02-features/traits/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "willdurand/geocoder": "~2.8"
+        "willdurand/geocoder": "^3.2"
     }
 }

--- a/02-features/traits/index.php
+++ b/02-features/traits/index.php
@@ -3,9 +3,9 @@ require 'vendor/autoload.php';
 require 'Geocodable.php';
 require 'RetailStore.php';
 
-$geocoderAdapter = new \Geocoder\HttpAdapter\CurlHttpAdapter();
-$geocoderProvider = new \Geocoder\Provider\GoogleMapsProvider($geocoderAdapter);
-$geocoder = new \Geocoder\Geocoder($geocoderProvider);
+$geocoderAdapter = new \Ivory\HttpAdapter\CurlHttpAdapter();
+$geocoder = new \Geocoder\ProviderAggregator();
+$geocoder->registerProvider(new \Geocoder\Provider\GoogleMaps($geocoderAdapter));
 
 $store = new RetailStore();
 $store->setAddress('420 9th Avenue, New York, NY 10001 USA');


### PR DESCRIPTION
This is an update to the example of traits to support newer versions of willdurand/geocoder (+3.x).

The Geocoder API since 3.x use HTTP Adapters and returns a list of addresses instead of only one. In consequence, the modified example,
- uses the egelon/ivory HTTP Adapter (included by default)
- uses the ProviderAggregator
- and obtains the results from the first address in the response.
